### PR TITLE
Added delay before changing GPIO output

### DIFF
--- a/captureimages.py
+++ b/captureimages.py
@@ -23,7 +23,8 @@ def takepic(channel=0):
         camera.start_preview()
         time.sleep(2)
         camera.capture(savelocation + str(time.strftime("%Y%m%d_%H%M%S")) + str(count) + '.jpg')
-
+        time.sleep(sleepaftertaking)
+        
 # main function of program
 def main(argv):
     role = argv[0]
@@ -36,7 +37,7 @@ def main(argv):
             GPIO.output(pin, GPIO.HIGH)
             takepic()
             GPIO.output(pin, GPIO.LOW)
-            time.sleep(sleepaftertaking)
+            time.sleep(3)
 
 
     else:


### PR DESCRIPTION
I think this is what is causing the corruption - that the master starts changing the GPIO output before it has finished saving the photo? Making this change reduced the number of corrupt photos to ~ 1 in 10
